### PR TITLE
Now using include files for lists of source code files to be Make'd

### DIFF
--- a/src/atmosphere/Makefile.in
+++ b/src/atmosphere/Makefile.in
@@ -1,12 +1,12 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-SOURCES=AtmosphericModel.cpp AtmosphericProperty1D.cpp Atmosphere1D.cpp ToyAtmosphere1D.cpp Atmosphere2D.cpp StratifiedAtmosphere2D.cpp ProfileSeriesAtmosphere2D.cpp AtmosphericProperty3D.cpp Atmosphere3D.cpp StratifiedAtmosphere3D.cpp ProfileGridAtmosphere3D.cpp Turbulence.cpp
+#SOURCES=AtmosphericModel.cpp AtmosphericProperty1D.cpp Atmosphere1D.cpp ToyAtmosphere1D.cpp Atmosphere2D.cpp StratifiedAtmosphere2D.cpp ProfileSeriesAtmosphere2D.cpp AtmosphericProperty3D.cpp Atmosphere3D.cpp StratifiedAtmosphere3D.cpp ProfileGridAtmosphere3D.cpp Turbulence.cpp
 OBJS=$(SOURCES:.cpp=.o)
 TARGET=libatmosphere.a
 

--- a/src/atmosphere/sources.make
+++ b/src/atmosphere/sources.make
@@ -1,0 +1,1 @@
+SOURCES=AtmosphericModel.cpp AtmosphericProperty1D.cpp Atmosphere1D.cpp ToyAtmosphere1D.cpp Atmosphere2D.cpp StratifiedAtmosphere2D.cpp ProfileSeriesAtmosphere2D.cpp AtmosphericProperty3D.cpp Atmosphere3D.cpp StratifiedAtmosphere3D.cpp ProfileGridAtmosphere3D.cpp Turbulence.cpp

--- a/src/common/Makefile.in
+++ b/src/common/Makefile.in
@@ -1,13 +1,11 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-#SOURCES=anyoption.cpp binaryreader.cpp geographic.cpp util.cpp units.cpp parameterset.cpp
-SOURCES=binaryreader.cpp geographic.cpp util.cpp units.cpp parameterset.cpp LANLInterpolation.cpp ncpa_fft.cpp
 
 OBJS=$(SOURCES:.cpp=.o)
 TARGET=libcommon.a

--- a/src/common/sources.make
+++ b/src/common/sources.make
@@ -1,0 +1,1 @@
+SOURCES=binaryreader.cpp geographic.cpp util.cpp units.cpp parameterset.cpp LANLInterpolation.cpp ncpa_fft.cpp

--- a/src/epade_pe/Makefile.in
+++ b/src/epade_pe/Makefile.in
@@ -1,12 +1,13 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-OBJS=epade_pe_parameters.o epade_pe_main.o
+#OBJS=epade_pe_parameters.o epade_pe_main.o
+OBJS=$(SOURCES:.cpp=.o)
 TARGET=ePape
 
 

--- a/src/epade_pe/sources.make
+++ b/src/epade_pe/sources.make
@@ -1,0 +1,1 @@
+SOURCES=epade_pe_parameters.cpp epade_pe_main.cpp

--- a/src/gfpe/Makefile.in
+++ b/src/gfpe/Makefile.in
@@ -1,12 +1,13 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-OBJS=gfpe_parameters.o gfpe_main.o
+#OBJS=gfpe_parameters.o gfpe_main.o
+OBJS=$(SOURCES:.cpp=.o)
 TARGET=gfpe
 
 

--- a/src/gfpe/sources.make
+++ b/src/gfpe/sources.make
@@ -1,0 +1,1 @@
+SOURCES=gfpe_parameters.cpp gfpe_main.cpp

--- a/src/libbroadband/Makefile.in
+++ b/src/libbroadband/Makefile.in
@@ -1,13 +1,12 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-#SOURCES=anyoption.cpp binaryreader.cpp geographic.cpp util.cpp units.cpp parameterset.cpp
-SOURCES=BroadbandPropagator.cpp ModalBroadbandPropagator.cpp
+#SOURCES=BroadbandPropagator.cpp ModalBroadbandPropagator.cpp
 
 OBJS=$(SOURCES:.cpp=.o)
 TARGET=libbroadband.a

--- a/src/libbroadband/sources.make
+++ b/src/libbroadband/sources.make
@@ -1,0 +1,1 @@
+SOURCES=BroadbandPropagator.cpp ModalBroadbandPropagator.cpp

--- a/src/libmodes/Makefile.in
+++ b/src/libmodes/Makefile.in
@@ -1,14 +1,11 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-#SOURCES=anyoption.cpp binaryreader.cpp geographic.cpp util.cpp units.cpp parameterset.cpp
-SOURCES=ModeSolver.cpp ESSModeSolver.cpp WModeSolver.cpp EigenEngine.cpp
-
 OBJS=$(SOURCES:.cpp=.o)
 TARGET=libmodes.a
 

--- a/src/libmodes/sources.make
+++ b/src/libmodes/sources.make
@@ -1,0 +1,1 @@
+SOURCES=ModeSolver.cpp ESSModeSolver.cpp WModeSolver.cpp EigenEngine.cpp

--- a/src/libpe/Makefile.in
+++ b/src/libpe/Makefile.in
@@ -1,12 +1,12 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-SOURCES=EPadeSolver.cpp GFPESolver.cpp
+#SOURCES=EPadeSolver.cpp GFPESolver.cpp
 
 OBJS=$(SOURCES:.cpp=.o)
 TARGET=libpe.a

--- a/src/libpe/sources.make
+++ b/src/libpe/sources.make
@@ -1,0 +1,1 @@
+SOURCES=EPadeSolver.cpp GFPESolver.cpp

--- a/src/modbb/Makefile.in
+++ b/src/modbb/Makefile.in
@@ -1,12 +1,13 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-OBJS=ModBB_main.o modbb_parameters.o #SolveModBB.o ProcessOptionsBB.o ModBB_lib.o
+#OBJS=ModBB_main.o modbb_parameters.o #SolveModBB.o ProcessOptionsBB.o ModBB_lib.o
+OBJS=$(SOURCES:.cpp=.o)
 TARGET=ModBB
 
 

--- a/src/modbb/sources.make
+++ b/src/modbb/sources.make
@@ -1,0 +1,1 @@
+SOURCES=ModBB_main.cpp modbb_parameters.cpp

--- a/src/modess/Makefile.in
+++ b/src/modess/Makefile.in
@@ -4,14 +4,14 @@ PETSC_ARCH_COMPLEX=@PETSC_ARCH_COMPLEX@
 
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-OBJS=Modess_main.o modess_parameters.o
-#ProcessOptionsNB.o 
+#OBJS=Modess_main.o modess_parameters.o
+OBJS=$(SOURCES:.cpp=.o)
 TARGET=Modess
 
 

--- a/src/modess/sources.make
+++ b/src/modess/sources.make
@@ -1,0 +1,1 @@
+SOURCES=Modess_main.cpp modess_parameters.cpp

--- a/src/wmod/Makefile.in
+++ b/src/wmod/Makefile.in
@@ -1,13 +1,13 @@
 include @PETSC_INCLUDE_FILE_GENERIC@
 include @SLEPC_INCLUDE_FILE_GENERIC@
-
+include sources.make
 
 # the following provides CCPPFLAGS, CLINKER, CC_INCLUDES, SLEPC_INCLUDE, SLEPC_LIB
 #include $(SLEPC_DIR)/conf/slepc_common
 
 INCPATHS = @INCLUDEFLAGS@ ${PETSC_CC_INCLUDES} ${SLEPC_CC_INCLUDES}
-#OBJS=WMod_main.o SolveWMod.o wmod_parameters.o
-OBJS=WMod_main.o wmod_parameters.o
+#OBJS=WMod_main.o wmod_parameters.o
+OBJS=$(SOURCES:.cpp=.o)
 TARGET=WMod
 
 

--- a/src/wmod/sources.make
+++ b/src/wmod/sources.make
@@ -1,0 +1,1 @@
+SOURCES=WMod_main.cpp wmod_parameters.cpp


### PR DESCRIPTION
Moved source code file names out of Makefiles into separate include files.  This will allow users to pull new source code files and have them included in the make process without having to run a new ./configure every time a new source file is added