### PR TITLE
Epape bug zero

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 NCPAProp Changelog
 
+2025-02-20:
+Fixed bug in ePape where in a rare case a square root of a negative number was
+computed and returned NaN; calculation was changed to assume complex values
+from the beginning.
+
 2025-02-17:
 Modified configure script to clone SLEPc from gitlab rather than
 directly downloading tar file.

--- a/src/libpe/EPadeSolver.cpp
+++ b/src/libpe/EPadeSolver.cpp
@@ -1752,10 +1752,11 @@ void NCPA::EPadeSolver::calculate_atmosphere_parameters(
 			drho = atm->get_first_derivative( r, "RHO", z_vec[ i ] );
 			ddrho = atm->get_second_derivative( r, "RHO", z_vec[ i ] );
 			k_vec[ i ] = std::sqrt(
+				std::complex<double>(
 							std::pow( 2.0 * PI * freq / c_vec[ i ], 2.0 )
 							- 0.75 * std::pow( drho / rho, 2.0 )
 							+ 0.5 * ddrho / rho
-						) + (a_vec[ i ] + abslayer[ i ]) * I;
+						,0.0)) + (a_vec[ i ] + abslayer[ i ]) * I;
 			//k_vec[ i ] = 2.0 * PI * freq / c_vec[ i ] + a_vec[ i ] * I;
 		}
 		n_vec[ i ] = k_vec[ i ] / k0;


### PR DESCRIPTION
Corrected bug found by user where a NaN returned from a (non-complex) square root caused the calculation to flatline.  Changed calculation to assume complex input and output.